### PR TITLE
Add: new facade and service requests to grab player and monster names…

### DIFF
--- a/app/controllers/encounters_controller.rb
+++ b/app/controllers/encounters_controller.rb
@@ -17,7 +17,8 @@ class EncountersController < ApplicationController
   end
 
   def index
-    @encounters = EncounterSimFacade.new.encounters(session[:user_id])
+    @facade = EncounterSimFacade.new
+    @encounters = @facade.encounters(session[:user_id])
   end
 
   private

--- a/app/facades/encounter_sim_facade.rb
+++ b/app/facades/encounter_sim_facade.rb
@@ -38,6 +38,11 @@ class EncounterSimFacade
     end
   end
 
+  def encounter_players(id)
+    results = @service.encounter_players(id)
+    Combat.new(results[:data][:attributes])
+  end
+
   def spell_names
     list = spell_list.map do |spell|
       spell.name

--- a/app/poros/combat.rb
+++ b/app/poros/combat.rb
@@ -1,0 +1,15 @@
+class Combat
+  attr_reader :p1, :p2, :p3, :p4, :p4, :monster
+  def initialize(data)
+    @p1 = data[:p1]
+    @p2 = data[:p2]
+    @p3 = data[:p3]
+    @p4 = data[:p4]
+    @p5 = data[:p5]
+    @monster = data[:monster]
+  end
+
+  def players
+    "#{@p1} #{@p2} #{@p3} #{@p4} #{@p5} #{@monster}"
+  end
+end

--- a/app/services/encounter_sim_service.rb
+++ b/app/services/encounter_sim_service.rb
@@ -24,6 +24,10 @@ class EncounterSimService
     get_url("/api/v1/encounters?user_id=#{id}")
   end
 
+  def encounter_players(id)
+    get_url("/api/v1/encounters/players?sim_id=#{id}")
+  end
+
   def encounter_creation(hash_data)
 
     post = conn.post "api/v1/encounters" do |req|

--- a/app/views/encounters/index.html.erb
+++ b/app/views/encounters/index.html.erb
@@ -1,6 +1,21 @@
 <div class="jumbotron text-center">
   <h1>Saved Encounters</h1>
 </div>
-<% @encounters.each do |encounter| %>
-  <h3><%= link_to encounter.id, "/encounters/#{encounter.id}", method: :get  %></h3><br>
-<% end %>
+<div>
+  <table class="table">
+    <thead>
+      <th scope="col">Encounter ID</th>
+      <th scope="col">Encounter characters</th>
+      <th scope="col">Encounter Link</th>
+    </thead>
+    <tbody>
+    <% @encounters.each do |encounter| %>
+      <tr>
+        <td><%= encounter.id %></td>
+        <td><%= @facade.encounter_players(encounter.id).players %></td>
+        <td><%= link_to "Link", "/encounters/#{encounter.id}", method: :get  %></td>
+      </tr>
+    </tbody>
+    <% end %>
+  </table>
+</div>


### PR DESCRIPTION
New facade and service call and PORO to facilitate improving encounters index page, it now shows the players and monster associated with an encounter, the encounter id and a link to the encounter results page


Neccesary checkmarks:

- [ ] All Tests are Passing

- [x] The code will run locally

Type of change

- [x] New feature
- [x] Bug Fix

Implements/Fixes:

    description closes open issue #

Check the correct boxes

- [x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

Testing Changes

- [ ] No Tests have been changed
- [ ] Some Tests have been changed

Checklist:

- [ ] My code has no unused/commented out code
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have fully tested my code


